### PR TITLE
Enable configuration of opendmarc and postfix message size limit

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -37,6 +37,8 @@
       ONE_DIR: "1"
       SPOOF_PROTECTION: "1"
       POSTMASTER_ADDRESS: "{{ mail_cert_email }}"
+      POSTFIX_MESSAGE_SIZE_LIMIT: "{{ postfix_message_size_limit }}"
+      ENABLE_OPENDMARC: "{{ enable_opendmarc }}"
       OVERRIDE_HOSTNAME: "{{ mail_domains.0 }}"
     published_ports:
       - "25:25"


### PR DESCRIPTION
By default opendmarc is used in the miters. Unfortunately, I have to receive email from a service where the mail server is apparently not configured correctly to make this work. So I need the option to disable it.
 
If you do not set the message size limit, it defaults to 10M, which for today's standards is on the low end. I want to accept larger attachments. 