### PR TITLE
Support v14 of docker-mailserver

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -37,6 +37,8 @@
       ONE_DIR: "1"
       SPOOF_PROTECTION: "1"
       POSTMASTER_ADDRESS: "{{ mail_cert_email }}"
+      POSTFIX_MESSAGE_SIZE_LIMIT: "{{ postfix_message_size_limit }}"
+      ENABLE_OPENDMARC: "{{ enable_opendmarc }}"
       OVERRIDE_HOSTNAME: "{{ mail_domains.0 }}"
     published_ports:
       - "25:25"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   template:
     dest: "{{ mail_persist_folder }}/amavis/custom-config.conf"
     src: amavis-custom-config.conf.j2
-    mode: 0600
+    mode: 0644
   notify: Restart mail service
 
 - name: Run docker container


### PR DESCRIPTION
I run auto update of my docker containers.
The recent v14 release broke my mailserver, I tracked it down to too strict file permissions that were generated by this role. This PR should fix it.